### PR TITLE
Renamed Cell Temperature to be equal to the other parameter 

### DIFF
--- a/esphome/atom_s3_lite_rs485.yaml
+++ b/esphome/atom_s3_lite_rs485.yaml
@@ -1116,8 +1116,7 @@ sensor:
       sorting_weight: 21
 
 ## version => BMS V2.15
-  - name: "Marstek Max. Cell Temperature"
-    id: "lilygo_rs485_marstek_max_cell_temperature"
+  - name: "Max. Cell Temperature"
     icon: mdi:thermometer
     platform: modbus_controller
     modbus_controller_id: mt
@@ -1135,8 +1134,7 @@ sensor:
       sorting_group_id: Info
       sorting_weight: 22
     
-  - name: "Marstek Min. Cell Temperature"
-    id: "lilygo_rs485_marstek_min_cell_temperature"
+  - name: "Min. Cell Temperature"
     icon: mdi:thermometer
     platform: modbus_controller
     modbus_controller_id: mt


### PR DESCRIPTION
I noticed the name was changed, this is now the only parameter with "Marstek" in the name. Was that your intention?

Also I don't think we want (this) `id` here.