### PR TITLE
Add 'Disabled' mode to BT Status sensor state mapping

### DIFF
--- a/esphome/atom_s3_lite_rs485_v3.yaml
+++ b/esphome/atom_s3_lite_rs485_v3.yaml
@@ -301,6 +301,7 @@ text_sensor:
         case 1:  mode_str = "Active after boot"; break;    
         case 2:  mode_str = "Connected"; break; 
         case 3:  mode_str = "Active"; break;                                                           
+        case 4:  mode_str = "Disabled"; break;
       }
       return mode_str;
     web_server:


### PR DESCRIPTION
A new case for mode 4 labeled 'Disabled' was added to the BT State state mapping.