### PR TITLE
WiFi‑signaalsterkte en ‑percentage toegevoegd voor atom_s3_lite_rs485_v3

### DIFF
--- a/esphome/atom_s3_lite_rs485_v3.yaml
+++ b/esphome/atom_s3_lite_rs485_v3.yaml
@@ -378,6 +378,29 @@ sensor:
       sorting_group_id: Diagnostic
       sorting_weight: 14
 
+  - platform: wifi_signal
+    name: "ESP WiFi Signal Strength"
+    id: esp_wifi_signal_strength
+    icon: mdi:wifi
+    update_interval: 60s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: Diagnostic
+      sorting_weight: 5
+
+  - platform: copy
+    name: "ESP WiFi Signal Percentage"
+    id: esp_wifi_signal_proc
+    source_id: esp_wifi_signal_strength
+    icon: mdi:wifi
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "%"
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: Diagnostic
+      sorting_weight: 4
+
   - name: "Battery Wifi Signal Strength"
     id: battery_wifi_signal_strength
     icon: mdi:wifi


### PR DESCRIPTION
Dit pull request voegt twee diagnostische ESPHome‑sensoren toe voor de **atom_s3_lite_rs485_v3**:

- WiFi‑signaalsterkte (dBm)  
- WiFi‑signaalpercentage (%)

Deze sensoren maken het eenvoudiger om de draadloze verbinding van de ESP te monitoren en eventuele bereik‑ of stabiliteitsproblemen te detecteren.

Ik heb deze toevoeging **alleen voor de atom_s3_lite_rs485_v3** gedaan, omdat ik de andere hardwarevarianten niet bezit en deze dus niet kan testen.

Een screenshot van de nieuwe diagnostische waarden in de webinterface :

<img width="689" height="685" alt="image" src="https://github.com/user-attachments/assets/ca77b9be-6e0f-4df7-9764-b41b126876c1" />
